### PR TITLE
Added easy dev release script

### DIFF
--- a/ZDragon.NET.sln
+++ b/ZDragon.NET.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
+		zdragon_release.sh = zdragon_release.sh
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mapper.XSD", "Mapper.XSD\Mapper.XSD.csproj", "{CC0033CB-E0DD-435D-B3E6-84C2A33DFBFC}"

--- a/zdragon_release.sh
+++ b/zdragon_release.sh
@@ -1,0 +1,10 @@
+# The following variables are defaults, but can be overwritten as cli arguments, such as by running zdragon_release /usr/local/tempBinForDev
+# This can be useful for one-time changes, but it is recommended to just edit the file if you want to do this often.
+
+# Default bin location for mac
+OUTPUT_DIR="${1:-/usr/local/bin}"
+# Defaults to mac
+OS="${2:-osx-x64}"
+# If your zdragon source location differs from this, edit this variable.
+SOURCE_DIR="${3:-$HOME/projects/ZDragon.NET/CLI}"
+dotnet publish "$SOURCE_DIR" -c Release --runtime "$OS" /p:PublishSingleFile=true -o "$OUTPUT_DIR"


### PR DESCRIPTION
A useful bash script for developers that want to test the release locally.

I recommend placing the zdragon_release script in your /usr/local/bin, so you can redeploy from your working folder after making changes in your editor, without having to switch from directory.
For the lazy among us:
```
cp zdragon_release.sh /usr/local/bin
# May be required, depends on git and cp
chmod +x /usr/local/bin/zdragon_release.sh
```